### PR TITLE
latest is deprecated?

### DIFF
--- a/02-terraform-basics-docker/05-Referencing-Other-Resources/main.tf
+++ b/02-terraform-basics-docker/05-Referencing-Other-Resources/main.tf
@@ -19,7 +19,7 @@ resource "docker_image" "nodered_image" {
 
 resource "docker_container" "nodered_container" {
   name  = "nodered"
-  image = docker_image.nodered_image.latest
+  image = docker_image.nodered_image.name
   ports {
     internal = 1880
     external = 1880


### PR DESCRIPTION
Derek, 
Going through some of your old stuff :-) 
Looks like 'latest' has been changed to 'name' ?
https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/image 